### PR TITLE
Update deprecated constants in const.py 

### DIFF
--- a/custom_components/smartevse/const.py
+++ b/custom_components/smartevse/const.py
@@ -1,18 +1,16 @@
 """Constants for the smartevse component."""
 from __future__ import annotations
-from homeassistant.const import TEMP_CELSIUS, ELECTRIC_CURRENT_AMPERE, ENERGY_KILO_WATT_HOUR, POWER_KILO_WATT, TIME_MINUTES
+from homeassistant.const import (
+    UnitOfElectricCurrent, 
+    UnitOfEnergy, 
+    UnitOfPower, 
+    UnitOfTemperature,
+    UnitOfTime,
+)
 
 from homeassistant.components.sensor import (
-    STATE_CLASS_MEASUREMENT,
-    STATE_CLASS_TOTAL_INCREASING,
     SensorDeviceClass,
     SensorStateClass,
-)
-from homeassistant.const import (
-    PERCENTAGE,
-    PRESSURE_BAR,
-    TEMP_CELSIUS,
-    VOLUME_CUBIC_METERS,
 )
 
 from .models import (
@@ -105,7 +103,7 @@ SENSORS: tuple[SmartEVSESensorEntityDescription, ...] = (
         key="smartevse_temp",
         name="SmartEVSE Temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
-        unit=TEMP_CELSIUS,
+        unit=UnitOfTemperature.CELSIUS,
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_access",
@@ -138,25 +136,25 @@ SENSORS: tuple[SmartEVSESensorEntityDescription, ...] = (
     SmartEVSESensorEntityDescription(
         key="smartevse_charge_current",
         name="SmartEVSE Charge Current",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_current_min",
         name="SmartEVSE Current Min",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_current_max",
         name="SmartEVSE Current Max",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_current_main",
         name="SmartEVSE Current Main",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
@@ -166,7 +164,7 @@ SENSORS: tuple[SmartEVSESensorEntityDescription, ...] = (
     SmartEVSESensorEntityDescription(
         key="smartevse_home_battery_current",
         name="SmartEVSE Home Battery Current",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
@@ -176,97 +174,97 @@ SENSORS: tuple[SmartEVSESensorEntityDescription, ...] = (
     SmartEVSESensorEntityDescription(
         key="smartevse_ev_import_active_energy",
         name="SmartEVSE EV Import Active Energy",
-        unit=ENERGY_KILO_WATT_HOUR,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_ev_export_active_energy",
         name="SmartEVSE EV Export Active Energy",
-        unit=ENERGY_KILO_WATT_HOUR,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_ev_import_active_power",
         name="SmartEVSE EV Import Active Power",
-        unit=POWER_KILO_WATT,
+        unit=UnitOfPower.KILO_WATT,
         device_class=SensorDeviceClass.POWER,
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_ev_total_kwh",
         name="SmartEVSE EV Total kWh",
-        unit=ENERGY_KILO_WATT_HOUR,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=STATE_CLASS_TOTAL_INCREASING
+        state_class=SensorStateClass.TOTAL_INCREASING
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_ev_charged_kwh",
         name="SmartEVSE EV Charged kWh",
-        unit=ENERGY_KILO_WATT_HOUR,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_ev_total",
         name="SmartEVSE EV Total",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_ev_l1",
         name="SmartEVSE EV L1",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_ev_l2",
         name="SmartEVSE EV L2",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_ev_l3",
         name="SmartEVSE EV L3",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_mains_import_active_energy",
         name="SmartEVSE Mains Import Active Energy",
-        unit=ENERGY_KILO_WATT_HOUR,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_mains_export_active_energy",
         name="SmartEVSE Mains Export Active Energy",
-        unit=ENERGY_KILO_WATT_HOUR,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_total",
         name="SmartEVSE Total Mains",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_l1",
         name="SmartEVSE Mains L1",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_l2",
         name="SmartEVSE Mains L2",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
         key="smartevse_l3",
         name="SmartEVSE Mains L3",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
@@ -312,7 +310,7 @@ NUMBERS: tuple[SmartEVSENumberEntityDescription, ...] = (
     SmartEVSENumberEntityDescription(
         key="smartevse_override_current",
         name="SmartEVSE Override Current",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         native_min_value=6,
         native_max_value=16,
@@ -322,7 +320,7 @@ NUMBERS: tuple[SmartEVSENumberEntityDescription, ...] = (
     SmartEVSENumberEntityDescription(
         key="smartevse_solar_max_import",
         name="SmartEVSE Solar Max Import",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         native_min_value=0,
         native_max_value=20,
@@ -332,7 +330,7 @@ NUMBERS: tuple[SmartEVSENumberEntityDescription, ...] = (
     SmartEVSENumberEntityDescription(
         key="smartevse_solar_start_current",
         name="SmartEVSE Solar Start Current",
-        unit=ELECTRIC_CURRENT_AMPERE,
+        unit=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         native_min_value=0,
         native_max_value=48,
@@ -342,7 +340,7 @@ NUMBERS: tuple[SmartEVSENumberEntityDescription, ...] = (
     SmartEVSENumberEntityDescription(
         key="smartevse_solar_stop_time",
         name="Solar Stop Time",
-        unit=TIME_MINUTES,
+        unit=UnitOfTime.MINUTES,
         #device_class=SensorDeviceClass.TIME,
         native_min_value=0,
         native_max_value=60,


### PR DESCRIPTION
HA 2024.1.0b2 throws the following warnings:

```py
2023-12-31 12:18:14.373 WARNING (MainThread) [homeassistant.const] TEMP_CELSIUS was used from smartevse, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please create a bug report at https://github.com/dingo35/ha-SmartEVSEv3/issues
2023-12-31 12:18:14.380 WARNING (MainThread) [homeassistant.const] ELECTRIC_CURRENT_AMPERE was used from smartevse, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfElectricCurrent.AMPERE instead, please create a bug report at https://github.com/dingo35/ha-SmartEVSEv3/issues
2023-12-31 12:18:14.384 WARNING (MainThread) [homeassistant.const] ENERGY_KILO_WATT_HOUR was used from smartevse, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfEnergy.KILO_WATT_HOUR instead, please create a bug report at https://github.com/dingo35/ha-SmartEVSEv3/issues
2023-12-31 12:18:14.389 WARNING (MainThread) [homeassistant.const] POWER_KILO_WATT was used from smartevse, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfPower.KILO_WATT instead, please create a bug report at https://github.com/dingo35/ha-SmartEVSEv3/issues
2023-12-31 12:18:14.393 WARNING (MainThread) [homeassistant.const] TIME_MINUTES was used from smartevse, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTime.MINUTES instead, please create a bug report at https://github.com/dingo35/ha-SmartEVSEv3/issues
2023-12-31 12:18:14.399 WARNING (MainThread) [homeassistant.components.sensor] STATE_CLASS_MEASUREMENT was used from smartevse, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorStateClass.MEASUREMENT instead, please create a bug report at https://github.com/dingo35/ha-SmartEVSEv3/issues
2023-12-31 12:18:14.404 WARNING (MainThread) [homeassistant.components.sensor] STATE_CLASS_TOTAL_INCREASING was used from smartevse, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorStateClass.TOTAL_INCREASING instead, please create a bug report at https://github.com/dingo35/ha-SmartEVSEv3/issues
2023-12-31 12:18:14.407 WARNING (MainThread) [homeassistant.components.sensor] STATE_CLASS_MEASUREMENT was used from smartevse, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorStateClass.MEASUREMENT instead, please create a bug report at https://github.com/dingo35/ha-SmartEVSEv3/issues
2023-12-31 12:18:14.412 WARNING (MainThread) [homeassistant.components.sensor] STATE_CLASS_TOTAL_INCREASING was used from smartevse, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorStateClass.TOTAL_INCREASING instead, please create a bug report at https://github.com/dingo35/ha-SmartEVSEv3/issues
2023-12-31 12:18:14.418 WARNING (MainThread) [homeassistant.const] PRESSURE_BAR was used from smartevse, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfPressure.BAR instead, please create a bug report at https://github.com/dingo35/ha-SmartEVSEv3/issues
2023-12-31 12:18:14.422 WARNING (MainThread) [homeassistant.const] TEMP_CELSIUS was used from smartevse, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please create a bug report at https://github.com/dingo35/ha-SmartEVSEv3/issues
2023-12-31 12:18:14.426 WARNING (MainThread) [homeassistant.const] VOLUME_CUBIC_METERS was used from smartevse, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfVolume.CUBIC_METERS instead, please create a bug report at https://github.com/dingo35/ha-SmartEVSEv3/issues
```

With this PR, all of those are fixed. Tested locally, works fine.

Fixes #19 