### PR TITLE
Force a refresh after updating settings in smartevse

### DIFF
--- a/custom_components/smartevse/number.py
+++ b/custom_components/smartevse/number.py
@@ -84,5 +84,4 @@ class SmartEVSENumber(SmartEVSEEntity, NumberEntity):
     def write(self):
         res = requests.post(self.api_url, {})
         if res.status_code == 200:
-            self.schedule_update_ha_state()
-
+            self.schedule_update_ha_state(force_refresh=True)

--- a/custom_components/smartevse/select.py
+++ b/custom_components/smartevse/select.py
@@ -89,4 +89,4 @@ class SmartEVSESelect(SmartEVSEEntity, SelectEntity):
         res = requests.post(self.api_url, {})
         if res.status_code == 200:
             self._attr_current_option = option
-            self.schedule_update_ha_state()
+            self.schedule_update_ha_state(force_refresh=True)

--- a/custom_components/smartevse/switch.py
+++ b/custom_components/smartevse/switch.py
@@ -72,4 +72,4 @@ class SmartEVSESwitch(SmartEVSEEntity, SwitchEntity):
     def write(self):
         res = requests.post(self.api_url, {})
         if res.status_code == 200:
-            self.schedule_update_ha_state()
+            self.schedule_update_ha_state(force_refresh=True)


### PR DESCRIPTION
After updating the settings in smartevse the changes are not immediately visible in the ui. So force the refresh instead of waiting up to a minute.