### PR TITLE
Settable smartevse_current_max_sum_mains

### DIFF
--- a/custom_components/smartevse/const.py
+++ b/custom_components/smartevse/const.py
@@ -170,12 +170,6 @@ SENSORS: tuple[SmartEVSESensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.CURRENT,
     ),
     SmartEVSESensorEntityDescription(
-        key="smartevse_current_max_sum_mains",
-        name="SmartEVSE Current MaxSumMains",
-        unit=UnitOfElectricCurrent.AMPERE,
-        device_class=SensorDeviceClass.CURRENT,
-    ),
-    SmartEVSESensorEntityDescription(
         key="smartevse_loadbl",
         name="SmartEVSE LoadBl",
     ),
@@ -327,6 +321,16 @@ NUMBERS: tuple[SmartEVSENumberEntityDescription, ...] = (
         native_step=0.1,
         entity_registry_enabled_default=True,
     ),
+    SmartEVSENumberEntityDescription(
+        key="smartevse_current_max_sum_mains",
+        name="SmartEVSE Grid Capacity Current",
+        unit=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        native_min_value=1,
+        native_max_value=600,
+        native_step=1,
+        entity_registry_enabled_default=True,
+    ),    
     SmartEVSENumberEntityDescription(
         key="smartevse_solar_max_import",
         name="SmartEVSE Solar Max Import",

--- a/custom_components/smartevse/number.py
+++ b/custom_components/smartevse/number.py
@@ -79,6 +79,8 @@ class SmartEVSENumber(SmartEVSEEntity, NumberEntity):
             self.api_url = "http://" + self._client.host + "/settings?solar_start_current=" + str(value)
         elif (self.entity_description.key == "smartevse_solar_max_import"):
             self.api_url = "http://" + self._client.host + "/settings?solar_max_import=" + str(value)
+        elif (self.entity_description.key == "smartevse_current_max_sum_mains"):
+            self.api_url = "http://" + self._client.host + "/settings?current_max_sum_mains=" + str(value)            
         await self.hass.async_add_executor_job(self.write)
 
     def write(self):


### PR DESCRIPTION
Changed smartevse_current_max_sum_mains from read-only sensor entity to settable number entity, so the max capacity can be dynamically updated using HA automations.

Considering the current Slovenian power network capacity restrictions, where every household can have 5 different power capacities depending on the season, work-day and hour of the day, it is crucial that home-assistant can dynamically set the network capacity on the SMART Evse. In this PR i have just added the EVSE API call to the existing endpoint and changed the entity in HA to input.


Just as an interesting info:
capacity blocks for households
![image](https://github.com/user-attachments/assets/7ea3c49f-89dc-4978-be01-a06d40c81f87)

Price per kW of capacity per block:
![image](https://github.com/user-attachments/assets/79e087e9-38d1-4b18-93b7-152370ef1006)
